### PR TITLE
Make logo installable through npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 ![logo-solid-bright](https://raw.githubusercontent.com/codingteam/logo/master/logo-solid-bright.png)
 ![logo-solid-dark](https://raw.githubusercontent.com/codingteam/logo/master/logo-solid-dark.png)
 
+## Installation
+
+If you want to use the logo in your project, one way of doing that is to install
+the logo through npm:
+
+```console
+$ npm install codingteam/logo#1.0.0 
+```
+
 ## License [![logo-cc-by][]][cc-by-license]
 
 This work is licensed under a [Creative Commons Attribution 4.0 International

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "codingteam-logo",
+  "version": "1.0.0",
+  "description": "The Logo of the Codingteam Foundation",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/codingteam/logo.git"
+  },
+  "keywords": [
+    "logo",
+    "resource",
+    "codingteam"
+  ],
+  "author": "codingteam",
+  "license": "CC-BY-4.0",
+  "bugs": {
+    "url": "https://github.com/codingteam/logo/issues"
+  },
+  "homepage": "https://github.com/codingteam/logo#readme"
+}


### PR DESCRIPTION
This is an essential part of https://github.com/codingteam/codingteam.org.ru/pull/52. Now anybody could install our artifact from GitHub using the npm standard functionality (npm uses the syntax `<GitHub user>/<GitHub repo>#<tag>`).

Later we could even publish the logo to npm repository, but I currently don't see a purpose for that.